### PR TITLE
Removing body, div, select format in CSS

### DIFF
--- a/sumoselect.css
+++ b/sumoselect.css
@@ -1,4 +1,3 @@
-﻿body, p, div, select { padding: 0; margin: 0; outline: none; color: #000; font-family: calibri; }
 .SlectBox, .SlectBoxa { width: 200px; padding: 5px; }
 
 /*this is applied on that hidden select. DO NOT USE display:none; or visiblity:hidden; and Do not override any of these properties. */


### PR DESCRIPTION
The current CSS file automatically formats the body font in a way that is unnecessary and can cause problems when added to existing sites. This patch removes that auto-formatting.