### PR TITLE
Close dropdown when focus is lost

### DIFF
--- a/jquery.sumoselect.js
+++ b/jquery.sumoselect.js
@@ -221,7 +221,9 @@
                         evt.stopPropagation();
                     });
 
-                    //O.backdrop.click(function () { O.hideOpts(); });
+		    O.E.on('focusout', function () {
+                        O.optDiv.removeClass('open');
+                    });
 
                     O.E.on('blur', function () {
                         O.optDiv.removeClass('open');


### PR DESCRIPTION
Added focusout event handler, so once focus is lost, open dropdown will be closed.