### PR TITLE
Bugfix csvDispCount value

### DIFF
--- a/jquery.sumoselect.js
+++ b/jquery.sumoselect.js
@@ -48,7 +48,7 @@
                 is_floating: false,
                 is_opened: false,
                 //backdrop: '',
-                mob:false, // if to open device default select
+                mob:false, // if to open device default select= settings.csvDispCount && settings.csvDis
                 Pstate: [],
 
                 createElems: function () {
@@ -383,7 +383,7 @@
                         sels = O.E.children(':selected').not(':disabled'); //selected options.
 
                         for (i = 0; i < sels.length; i++) {
-                            if (i >= settings.csvDispCount && settings.csvDispCount) {
+                            if (i + 1 >= settings.csvDispCount && settings.csvDispCount) {
                                 O.placeholder = settings.captionFormat.replace('{0}', sels.length);
                                 //O.placeholder = i + '+ Selected';
                                 break;

--- a/jquery.sumoselect.js
+++ b/jquery.sumoselect.js
@@ -48,7 +48,7 @@
                 is_floating: false,
                 is_opened: false,
                 //backdrop: '',
-                mob:false, // if to open device default select= settings.csvDispCount && settings.csvDis
+                mob:false, // if to open device default select
                 Pstate: [],
 
                 createElems: function () {


### PR DESCRIPTION
There is a bug in handling csvDispCount option.
One is not able to apply captionFormat placeholder if choose only 1(one) option in list, even if he set csvDispCount as "1".
The minimum number to show captionFormat placeholder is 2, and I belive this is not correct behavior.