### PR TITLE
showTitle option (true by default) to control if title (tooltip) should be rendered

### DIFF
--- a/jquery.sumoselect.js
+++ b/jquery.sumoselect.js
@@ -33,7 +33,8 @@
             noMatch: 'No matches for "{0}"',
             prefix: '',                   // some prefix usually the field name. eg. '<b>Hello</b>'
             locale: ['OK', 'Cancel', 'Select All'],  // all text that is used. don't change the index.
-            up: false                     // set true to open upside.
+            up: false,                    // set true to open upside.
+            showTitle: true               // set to false to prevent title (tooltip) from appearing
         }, options);
 
         var ret = this.each(function () {
@@ -484,7 +485,7 @@
 
                     //set display text
                     O.caption.html(O.placeholder);
-                    O.CaptionCont.attr('title', O.placeholder);
+                    if (settings.showTitle) O.CaptionCont.attr('title', O.placeholder);
 
                     //set the hidden field if post as csv is true.
                     csvField = O.select.find('input.HEMANT123');


### PR DESCRIPTION
Tooltip is generally useful (especially for multi-select lists) hence the option is set to true by default. But if sumoselect sits on a form with other controls that don't use title attribute it's better not to render it (for UI consistency)...
