### PR TITLE
Fix the bug that toggSelAll function doesn't work properly when select element have optgroups.

### DIFF
--- a/jquery.sumoselect.js
+++ b/jquery.sumoselect.js
@@ -594,10 +594,10 @@
                 toggSelAll: function (c) {
                     var O = this;
                     O.E.find('option').each(function (ix, el) {
-                        if (O.E.find('option')[$(this).index()].disabled) return;
-                        O.E.find('option')[$(this).index()].selected = c;
+                        if (O.E.find('option')[ix].disabled) return;
+                        O.E.find('option')[ix].selected = c;
                         if (!O.mob)
-							O.optDiv.find('ul.options li').eq($(this).index()).toggleClass('selected', c);
+							O.optDiv.find('ul.options li.opt').eq($(this).index()).toggleClass('selected', c);
                         O.setText();
                     });
                     if(!O.mob && O.selAll)O.selAll.removeClass('partial').toggleClass('selected',c);


### PR DESCRIPTION
I found there is something wrong with toggSelAll function.

First, I made a sumoselect with multiple option using a select element which have optgroups. 

After that, I called toggSelAll() function to set all options are selected.

But, It doesn't work properly. Sad...

So I checked your code and fixed this bug like the patch below.

Please consider this patch. I'd appreciate you could review and apply this to master.

It doesn't matter what you want to fix this bug by other ways.

Thanks.

Regards.