### PR TITLE
Fix the bug that 'No matched found for' message doesn't appeared on IE.

### DIFF
--- a/sumoselect.css
+++ b/sumoselect.css
@@ -33,7 +33,7 @@
         .SumoSelect.open > .optWrapper {top:35px; display:block;}
         .SumoSelect.open > .optWrapper.up {top: auto;bottom: 100%;margin-bottom: 5px;}
 
-        .SumoSelect > .optWrapper ul {list-style: none; display: block; padding: 0; margin: 0; overflow: auto;}
+        .SumoSelect > .optWrapper ul {list-style: none; display: inline; padding: 0; margin: 0; overflow: auto;}
         .SumoSelect > .optWrapper > .options { border-radius: 2px;position:relative;
          /*Set the height of pop up here (only for desktop mode)*/
             max-height: 250px;


### PR DESCRIPTION
Please refer to the issue https://github.com/HemantNegi/jquery.sumoselect/issues/149

I already commented on this issue. and I thought this bug is related with cross browsing.

Please review this, and give me a feedback.

Thanks.