### PR TITLE
Add an option to show on top of list previously selected items

### DIFF
--- a/jquery.sumoselect.js
+++ b/jquery.sumoselect.js
@@ -49,6 +49,7 @@
             locale: ['OK', 'Cancel', 'Select All'],  // all text that is used. don't change the index.
             up: false,                    // set true to open upside.
             showTitle: true               // set to false to prevent title (tooltip) from appearing
+            selectedFirst: false          // Show on top of list previously selected itmems
         }, options);
 
         var ret = this.each(function () {
@@ -136,6 +137,12 @@
 
                 prepItems: function (opts, d) {
                     var lis = [], O = this;
+                    if(settings.selectedFirst)
+                        opts.sort(function(a,b){
+                            if(a.selected && !b.selected) return -1;
+                            if(b.selected && !a.selected) return 1;
+                            return 0;
+                        });
                     $(opts).each(function (i, opt) {       // parsing options to li
                         opt = $(opt);
                         lis.push(opt.is('optgroup') ?

--- a/jquery.sumoselect.js
+++ b/jquery.sumoselect.js
@@ -48,7 +48,7 @@
             prefix: '',                   // some prefix usually the field name. eg. '<b>Hello</b>'
             locale: ['OK', 'Cancel', 'Select All'],  // all text that is used. don't change the index.
             up: false,                    // set true to open upside.
-            showTitle: true               // set to false to prevent title (tooltip) from appearing
+            showTitle: true,              // set to false to prevent title (tooltip) from appearing
             selectedFirst: false          // Show on top of list previously selected itmems
         }, options);
 


### PR DESCRIPTION
I like my customer to see immedialty after pulling down the (multiselect) list the selected items.
Hence, I think I'll also add the baility to reorder the options list after a new (de)selection is done.