### PR TITLE
enable placeholder for single selects, if not empty

### DIFF
--- a/jquery.sumoselect.js
+++ b/jquery.sumoselect.js
@@ -530,7 +530,11 @@
                         O.placeholder = O.placeholder.replace(/,([^,]*)$/, '$1'); //remove unexpected "," from last.
                     }
                     else {
-                        O.placeholder = O.E.find(':selected').not(':disabled').text();
+                        if ( settings.placeholder ) {
+                            O.placeholder = settings.placeholder;
+                        } else {
+                            O.placeholder = O.E.find(':selected').not(':disabled').text();
+                        }
                     }
 
                     var is_placeholder = false;


### PR DESCRIPTION
The workaround with creating a deactivated option as mentioned in #249 does not replace a real placeholder.