### PR TITLE
Select All bug on disabled and selected options

### DIFF
--- a/jquery.sumoselect.js
+++ b/jquery.sumoselect.js
@@ -304,9 +304,9 @@
                     var O = this;
                     if (settings.selectAll && O.is_multi) {
                         var sc = 0, vc = 0;
-                        O.optDiv.find('li.opt').not('.hidden').each(function (ix, e) {
+                        O.optDiv.find('li.opt').not('.hidden .disabled').each(function (ix, e) {
                             if ($(e).hasClass('selected')) sc++;
-                            if (!$(e).hasClass('disabled')) vc++;
+                            vc++;
                         });
                         //select all checkbox state change.
                         if (sc === vc) O.selAll.removeClass('partial').addClass('selected');


### PR DESCRIPTION
 SelectAll behaves buggy when select has both selected and disabled options in it like below.
```
<select id="island1" multiple>
  <option value="Big Island">Big Island</option>
  <option disabled selected value="Oahu">Oahu</option>
  <option value="Kauai">Kauai</option>
  <option disabled selected value="Maui">Maui</option>
  <option value="ist">ist</option>
 <option value="mist">mist</option>
</select>
```
