### PR TITLE
Escape text to prevent XSS

### DIFF
--- a/jquery.sumoselect.js
+++ b/jquery.sumoselect.js
@@ -139,7 +139,10 @@
                     $(opts).each(function (i, opt) {       // parsing options to li
                         opt = $(opt);
                         lis.push(opt.is('optgroup') ?
-                            $('<li class="group ' + (opt[0].disabled ? 'disabled' : '') + '"><label>' + opt.attr('label') + '</label><ul></ul></li>')
+                            $('<li class="group ' + (opt[0].disabled ? 'disabled' : '') + '"><label></label><ul></ul></li>')
+                                .find('label')
+                                .text(opt.attr('label'))
+                                .end()
                                 .find('ul')
                                 .append(O.prepItems(opt.children(), opt[0].disabled))
                                 .end()

--- a/jquery.sumoselect.js
+++ b/jquery.sumoselect.js
@@ -156,7 +156,7 @@
                     var O = this;
 
                     if (!opt.attr('value')) opt.attr('value', opt.val());
-                    var li = $('<li class="opt"><label>' + opt.text() + '</label></li>');
+                    var li = $('<li class="opt"><label>' + opt.html() + '</label></li>');
 
                     li.data('opt', opt);    // store a direct reference to option.
                     opt.data('li', li);    // store a direct reference to list item.
@@ -547,7 +547,7 @@
                     O.placeholder = O.placeholder ? (settings.prefix + ' ' + O.placeholder) : settings.placeholder
 
                     //set display text
-                    O.caption.html(O.placeholder);
+                    O.caption.text(O.placeholder);
                     if (settings.showTitle) O.CaptionCont.attr('title', O.placeholder);
 
                     //set the hidden field if post as csv is true.


### PR DESCRIPTION
Continuation of https://github.com/HemantNegi/jquery.sumoselect/pull/145

> Even when the original element contains well escaped html characters, jquery.sumoselect would render the custom widget with unescaped html characters.