### PR TITLE
Pass along element through searchFn

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Below are the available settings:
 
 - `nativeOnDevice`  `(Array[string])` The keywords to identify a mobile device from useragent string. The system default select list is rendered on the matched device.
 
-- `outputAsCSV` `(boolean)` `true` to POST data as csv ( false for deafault select )
+- `outputAsCSV` `(boolean)` `true` to POST data as csv ( false for default select )
 
 - `csvSepChar` `(string)`  Seperation char if `outputAsCSV`  is set to `true`
 
@@ -159,7 +159,7 @@ Below are the available settings:
 
 - `searchText` `(string)`  placeholder for search input.
 
-- `searchFn` `(function)`  Custom search function.
+- `searchFn` `(function)`  Custom search function. Following parameters will be passed along: haystack, needle, el
 
 - `noMatch` `(string)`  placeholder to display if no itmes matches the search term (default 'No matches for "{0}"').
 
@@ -194,7 +194,7 @@ Below are the available settings:
     selectAll: false,
     search: false,
     searchText: 'Search...',
-    searchFn: function (haystack, needle) {
+    searchFn: function (haystack, needle, el) {
       return haystack.toLowerCase().indexOf(needle.toLowerCase()) < 0;
     },
     noMatch: 'No matches for "{0}"',

--- a/docs/index.html
+++ b/docs/index.html
@@ -375,7 +375,7 @@
     <span class="nx">selectAll</span> <span class="o">:</span> <span class="kc">false</span><span class="p">,</span>
     <span class="nx">search</span> <span class="o">:</span> <span class="kc">false</span><span class="p">,</span>
     <span class="nx">searchText</span> <span class="o">:</span> <span class="kc">'Search...'</span><span class="p">,</span>
-    <span class="nx">searchFn</span> <span class="o">:</span> <span class="kc">function(haystack, needle){ ... }</span><span class="p">,</span>
+    <span class="nx">searchFn</span> <span class="o">:</span> <span class="kc">function(haystack, needle, el){ ... }</span><span class="p">,</span>
     <span class="nx">noMatch</span> <span class="o">:</span> <span class="kc">'No matches for "{0}"'</span><span class="p">,</span>
     <span class="nx">prefix</span> <span class="o">:</span> <span class="kc">''</span><span class="p">,</span>
     <span class="nx">locale</span> <span class="o">:</span> <span class="p"> [</span><span

--- a/jquery.sumoselect.js
+++ b/jquery.sumoselect.js
@@ -354,7 +354,7 @@
             const hid = O.optDiv.find('ul.options li.opt').each((ix, e) => {
               const el = $(e),
                 {0: opt} = el.data('opt');
-              opt.hidden = fn(el.text(), O.ftxt.val());
+              opt.hidden = fn(el.text(), O.ftxt.val(), el);
               el.toggleClass('hidden', opt.hidden);
             }).not('.hidden');
 


### PR DESCRIPTION
Usecase for this: we can then use the element to look at the parent group, and show all elements that are found in the group above.

Group name
- Item 1
- Item 2
- Item 3

searchFn:

```
searchFn: function (haystack, needle, el) { // search function
     var elementContains = haystack.toLowerCase().indexOf(needle.toLowerCase()) !== -1;
     var groupContains = el.closest('.group').length ? el.parent().parent().find('label:first-child').html().toLowerCase().indexOf(needle.toLowerCase()) !== -1 : false;

     return !elementContains && !groupContains;
}
```

When searching for 'Group name', it will show all the 3 items, even tho the items don't have that search term.

Open for better implementations! Would be awesome to have optgroup search natively in sumoselect.